### PR TITLE
Fix L4D2_VotePass

### DIFF
--- a/addons/sourcemod/scripting/nativevotes/game.sp
+++ b/addons/sourcemod/scripting/nativevotes/game.sp
@@ -2043,7 +2043,7 @@ static void L4D2_DisplayVote(NativeVote vote, int[] clients, int num_clients)
 static void L4D2_VotePass(const char[] translation, const char[] details, int team, int client=0)
 {
 	BfWrite votePass;
-	if (!client)
+	if (client <= 0)
 	{
 		votePass = UserMessageToBfWrite(StartMessageAll("VotePass", USERMSG_RELIABLE));
 	}


### PR DESCRIPTION
Fix this
```log
L 09/11/2021 - 10:50:05: [SM] Exception reported: Client index -1 is invalid
L 09/11/2021 - 10:50:05: [SM] Blaming: new/nativevotes.smx
L 09/11/2021 - 10:50:05: [SM] Call stack trace:
L 09/11/2021 - 10:50:05: [SM]   [0] StartMessage
L 09/11/2021 - 10:50:05: [SM]   [1] Line 269, C:\Users\sakura\Desktop\sourcemod_1.11_Compiler\include\usermessages.inc::StartMessageOne
L 09/11/2021 - 10:50:05: [SM]   [2] Line 2052, nativevotes\game.sp::L4D2_VotePass
L 09/11/2021 - 10:50:05: [SM]   [3] Line 733, nativevotes\game.sp::Game_DisplayRawVotePass
L 09/11/2021 - 10:50:05: [SM]   [4] Line 696, nativevotes\game.sp::Game_DisplayVotePassEx
L 09/11/2021 - 10:50:05: [SM]   [5] Line 689, nativevotes\game.sp::Game_DisplayVotePass
L 09/11/2021 - 10:50:05: [SM]   [6] Line 2125, nativevotes.sp::Native_DisplayPass
L 09/11/2021 - 10:50:05: [SM]   [8] NativeVote.DisplayPass
L 09/11/2021 - 10:50:05: [SM]   [9] Line 89, c:\Users\sakura\Desktop\TmpCompile\vote_test.sp::YesNoCustomHandler
L 09/11/2021 - 10:50:05: [SM]   [11] Call_Finish
L 09/11/2021 - 10:50:05: [SM]   [12] Line 833, nativevotes.sp::DoAction
L 09/11/2021 - 10:50:05: [SM]   [13] Line 871, nativevotes.sp::OnVoteResults
L 09/11/2021 - 10:50:05: [SM]   [14] Line 1123, nativevotes.sp::EndVoting
L 09/11/2021 - 10:50:05: [SM]   [15] Line 1063, nativevotes.sp::DecrementPlayerCount
L 09/11/2021 - 10:50:05: [SM]   [16] Line 817, nativevotes.sp::OnClientEnd
L 09/11/2021 - 10:50:05: [SM]   [17] Line 694, nativevotes.sp::Command_Vote
L 09/11/2021 - 10:50:05: [SM]   [19] FakeClientCommand
L 09/11/2021 - 10:50:05: [SM]   [20] Line 952, nativevotes\game.sp::Game_VoteYes
L 09/11/2021 - 10:50:05: [SM]   [21] Line 1285, nativevotes.sp::StartVoting
L 09/11/2021 - 10:50:05: [SM]   [22] Line 1174, nativevotes.sp::StartVote
L 09/11/2021 - 10:50:05: [SM]   [23] Line 1631, nativevotes.sp::Native_Display
L 09/11/2021 - 10:50:05: [SM]   [25] NativeVote.DisplayVote
L 09/11/2021 - 10:50:05: [SM]   [26] Line 46, c:\Users\sakura\Desktop\TmpCompile\vote_test.sp::votenum
```