### PR TITLE
Fix L4D2_VotePass again

### DIFF
--- a/addons/sourcemod/scripting/nativevotes/game.sp
+++ b/addons/sourcemod/scripting/nativevotes/game.sp
@@ -730,7 +730,7 @@ void Game_DisplayRawVotePass(NativeVotesPassType passType, int team, int client=
 				
 				default:
 				{
-					L4D2_VotePass(translation, details, client, team);
+					L4D2_VotePass(translation, details, team, client);
 				}
 			}
 		}
@@ -2043,7 +2043,7 @@ static void L4D2_DisplayVote(NativeVote vote, int[] clients, int num_clients)
 static void L4D2_VotePass(const char[] translation, const char[] details, int team, int client=0)
 {
 	BfWrite votePass;
-	if (client <= 0)
+	if (!client)
 	{
 		votePass = UserMessageToBfWrite(StartMessageAll("VotePass", USERMSG_RELIABLE));
 	}


### PR DESCRIPTION
Apologize for my recklessness.  #9 

I have been thinking, why does the client index have -1? , After careful inspection, the problem was found.

The position of the two parameters of `team` and `client` is wrong.
