### PR TITLE
Warning error to message

### DIFF
--- a/addons/sourcemod/scripting/nativevotes_mapchooser.sp
+++ b/addons/sourcemod/scripting/nativevotes_mapchooser.sp
@@ -287,7 +287,7 @@ public void OnConfigsExecuted()
 	{
 		if (g_Cvar_Bonusroundtime.FloatValue <= g_Cvar_VoteDuration.FloatValue)
 		{
-			LogError("Warning - Bonus Round Time shorter than Vote Time. Votes during bonus round may not have time to complete");
+			LogMessage("Warning - Bonus Round Time shorter than Vote Time. Votes during bonus round may not have time to complete");
 		}
 	}
 }


### PR DESCRIPTION
This doesn't need to be dumping warning messages into an error file. It should be more of a warning since mp_chattime can contribute to the vote time.