### PR TITLE
Hotfix for 2022-06-22

### DIFF
--- a/addons/sourcemod/scripting/nativevotes.sp
+++ b/addons/sourcemod/scripting/nativevotes.sp
@@ -667,8 +667,8 @@ public Action Command_Vote(int client, const char[] command, int argc)
 		return Plugin_Continue;
 	}
 	
-	char option[32];
-	GetCmdArg(1, option, sizeof(option));
+	char option[64];
+	GetCmdArgString(option, sizeof(option));
 	
 	int item = Game_ParseVote(option);
 	
@@ -1124,6 +1124,10 @@ void EndVoting()
 	 */
 	NativeVote vote = g_hCurVote;
 	Internal_Reset();
+	
+#if defined LOG
+	LogMessage("Voting done");
+#endif
 	
 	/* Send vote info */
 	OnVoteResults(vote, votes, num_votes, num_items, client_list, num_clients);

--- a/addons/sourcemod/scripting/nativevotes.sp
+++ b/addons/sourcemod/scripting/nativevotes.sp
@@ -112,6 +112,8 @@ int g_ClientVotes[MAXPLAYERS+1];
 bool g_bRevoting[MAXPLAYERS+1];
 char g_LeaderList[1024];
 
+ConVar sv_vote_holder_may_vote_no;
+
 // Map list stuffs
 
 #define STRINGTABLE_NAME					"ServerMapCycle"
@@ -261,6 +263,8 @@ public void OnPluginStart()
 	HookConVarChange(g_Cvar_VoteDelay, OnVoteDelayChange);
 
 	AddCommandListener(Command_Vote, "vote"); // All games, command listeners aren't case sensitive
+	
+	sv_vote_holder_may_vote_no = FindConVar("sv_vote_holder_may_vote_no");
 	
 	// The new version of the CallVote system is TF2 only
 	if (Game_AreVoteCommandsSupported())

--- a/addons/sourcemod/scripting/nativevotes.sp
+++ b/addons/sourcemod/scripting/nativevotes.sp
@@ -655,6 +655,12 @@ public void OnMapEnd()
 
 public Action Command_Vote(int client, const char[] command, int argc)
 {
+#if defined LOG
+	char voteString[128];
+	GetCmdArgString(voteString, sizeof(voteString));
+	LogMessage("Client %N ran a vote command: %s", client, voteString);
+#endif
+	
 	// If we're not running a vote, return the vote control back to the server
 	if (!Internal_IsVoteInProgress() || g_ClientVotes[client] != VOTE_PENDING)
 	{

--- a/addons/sourcemod/scripting/nativevotes/game.sp
+++ b/addons/sourcemod/scripting/nativevotes/game.sp
@@ -2139,6 +2139,9 @@ static int CSGO_ParseVote(const char[] option)
 // NATIVEVOTES_VOTE_INVALID means parse failed
 static int TF2_ParseVote(const char[] option)
 {
+	// the update on 2022-06-22 changed the params passed to the `vote` command
+	// previously it was a single string "optionN", where N was the option to be selected
+	// now it's two arguments "X optionN", where X is the vote index being acted on
 	char arg1[8];
 	int iArg2 = BreakString(option, arg1, sizeof(arg1));
 	
@@ -2276,8 +2279,9 @@ static void TF2CSGO_DisplayVote(NativeVote vote, int[] clients, int num_clients)
 		}
 		
 		// TODO(UPDATE): M-M-M-MULTIVOTE
-		// s_nNativeVoteIdx = GetEntProp(g_VoteController, Prop_Send, "m_nVoteIdx");
-		s_nNativeVoteIdx = -1;
+		// we need unique vote indices; HUD elements for previous votes aren't cleaned up (?)
+		// the game implements this as `this->m_nVoteIdx = s_nVoteIdx++`
+		s_nNativeVoteIdx = GetEntProp(g_VoteController, Prop_Send, "m_nVoteIdx");
 #if defined LOG
 		PrintToServer("Starting vote index: %d (controller: %d)", s_nNativeVoteIdx, GetEntProp(g_VoteController, Prop_Send, "m_nVoteIdx"));
 #endif

--- a/addons/sourcemod/scripting/nativevotes/game.sp
+++ b/addons/sourcemod/scripting/nativevotes/game.sp
@@ -2247,7 +2247,7 @@ static void TF2CSGO_DisplayVote(NativeVote vote, int[] clients, int num_clients)
 		
 		// TODO(UPDATE): M-M-M-MULTIVOTE
 		// s_nNativeVoteIdx = GetEntProp(g_VoteController, Prop_Send, "m_nVoteIdx");
-		s_nNativeVoteIdx = 0;
+		s_nNativeVoteIdx = -1;
 #if defined LOG
 		PrintToServer("Starting vote index: %d", s_nNativeVoteIdx);
 #endif

--- a/addons/sourcemod/scripting/nativevotes/game.sp
+++ b/addons/sourcemod/scripting/nativevotes/game.sp
@@ -2320,6 +2320,13 @@ static void TF2CSGO_DisplayVote(NativeVote vote, int[] clients, int num_clients)
 		SetEntProp(g_VoteController, Prop_Send, "m_nPotentialVotes", num_clients);
 	}
 
+	// required to allow the initiator to vote on their own issue
+	// ValveSoftware/Source-1-Games#3934
+	if (sv_vote_holder_may_vote_no && vote.Initiator <= MaxClients)
+	{
+		sv_vote_holder_may_vote_no.ReplicateToClient(vote.Initiator, "1");
+	}
+
 	MenuAction actions = Data_GetActions(vote);
 
 	for (int i = 0; i < num_clients; ++i)
@@ -2377,6 +2384,7 @@ static void TF2CSGO_DisplayVote(NativeVote vote, int[] clients, int num_clients)
 			}
 			bfStart.WriteBool(bYesNo);
 		}
+		
 		EndMessage();
 	}
 	

--- a/addons/sourcemod/scripting/nativevotes/game.sp
+++ b/addons/sourcemod/scripting/nativevotes/game.sp
@@ -2439,6 +2439,7 @@ static void TF2_VotePass(const char[] translation, const char[] details, int tea
 	}
 
 	votePass.WriteByte(team);
+	votePass.WriteNum(s_nNativeVoteIdx);
 	votePass.WriteString(translation);
 	votePass.WriteString(details);
 


### PR DESCRIPTION
Closes #14 and replaces #15.

PR makes the following changes:

- Parses updated version of `vote` command
- Adds vote index values to all vote events and usermessages
- Replicates `sv_vote_holder_may_vote_no` to the initiator so they can cast a vote for issues they've initiated

Some additional work is likely necessary to avoid stomping on the game's own vote indices (I think having our own static variable and setting it to 0x40000000 initially would be enough here, or for extra spiciness, just pass the raw NativeVotes handle value through the usermessages / events), and for supporting per-team + global concurrent votes.

Also, `ParseVote` should probably be modified to ~~identify the vote type~~ do something with the vote index.

~~The initiator of a vote cannot use F1-F5 keybindings to cast a vote; this is a Valve bug (see issue linked in #14).  Votes initiated by the server are reportedly working.~~

Tested with a modified `nativevotes_votetest.sp` where `NativeVote.Initiator` is set to `NATIVEVOTES_SERVER_INDEX`.