### PR TITLE
Remove throwerror

### DIFF
--- a/addons/sourcemod/scripting/nativevotes.sp
+++ b/addons/sourcemod/scripting/nativevotes.sp
@@ -2008,7 +2008,7 @@ public int Native_RedrawClientVote(Handle plugin, int numParams)
 		// When revoting in TF2, NativeVotes_IsVoteInProgress always gets skipped because of Game_IsVoteInProgress() 
 		// 	TF2s vote controller will stay alive a few seconds after the vote is complete
 		// 	If one tries to revote right as a vote completes, it will throw an error
-		//ThrowNativeError(SP_ERROR_NATIVE, "No vote is in progress");
+		LogError(SP_ERROR_NATIVE, "No vote is in progress");
 		return false;
 	}
 	

--- a/addons/sourcemod/scripting/nativevotes.sp
+++ b/addons/sourcemod/scripting/nativevotes.sp
@@ -2005,7 +2005,10 @@ public int Native_RedrawClientVote(Handle plugin, int numParams)
 	
 	if (!Internal_IsVoteInProgress())
 	{
-		ThrowNativeError(SP_ERROR_NATIVE, "No vote is in progress");
+		// When revoting in TF2, NativeVotes_IsVoteInProgress always gets skipped because of Game_IsVoteInProgress() 
+		// 	TF2s vote controller will stay alive a few seconds after the vote is complete
+		// 	If one tries to revote right as a vote completes, it will throw an error
+		//ThrowNativeError(SP_ERROR_NATIVE, "No vote is in progress");
 		return false;
 	}
 	


### PR DESCRIPTION
When revoting in TF2, [nativevotes-basecommands.sp#L131](https://github.com/sapphonie/sourcemod-nativevotes-updated/blob/master/addons/sourcemod/scripting/nativevotes-basecommands.sp#L131) always gets skipped because of [`NativeVotes_IsVoteInProgress()`](https://github.com/sapphonie/sourcemod-nativevotes-updated/blob/master/addons/sourcemod/scripting/nativevotes.sp#L1870) > `Game_IsVoteInProgress()`, TF2s vote controller will stay alive a few seconds after the vote is complete. If one tries to revote right as a vote completes, it will throw an error. This could be worked around by seperating `Internal_IsVoteInProgress()` and `Game_IsVoteInProgress()` from `Native_IsVoteInProgress()`, but since `Internal_IsVoteInProgress()` gets checked here anyway, we can just disable the throwerror instead.