### PR TITLE
CallVote client check

### DIFF
--- a/addons/sourcemod/scripting/nativevotes.sp
+++ b/addons/sourcemod/scripting/nativevotes.sp
@@ -391,7 +391,7 @@ public Action Command_CallVote(int client, const char[] command, int argc)
 		return Plugin_Continue;
 	}
 	
-	if (Internal_IsVoteInProgress() || Game_IsVoteInProgress())
+	if (Internal_IsVoteInProgress() || Game_IsVoteInProgress() || !IsClientInGame(client))
 	{
 		return Plugin_Handled;
 	}


### PR DESCRIPTION
Rare error where if a client is forced to re-call the vote as a map changes or the client disconnects