### PR TITLE
Add basic Pre-Fortress 2 support

### DIFF
--- a/addons/sourcemod/scripting/nativevotes/game.sp
+++ b/addons/sourcemod/scripting/nativevotes/game.sp
@@ -391,7 +391,7 @@ bool Game_IsGameSupported(char[] engineName="", int maxlength=0)
 	}
 
 	//Fix for Open Fortress
-	if ( g_EngineVersion == Engine_SDK2013 && ( StrEqual(gameDir, "open_fortress") || StrEqual(gameDir, "tf2classic") ) )
+	if ( g_EngineVersion == Engine_SDK2013 && ( StrEqual(gameDir, "open_fortress") || StrEqual(gameDir, "tf2classic") || StrEqual(gameDir, "pf2") ) )
 	{
 		g_EngineVersion = Engine_TF2;
 	}
@@ -3720,3 +3720,4 @@ stock bool Game_IsVoteTypeYesNo(NativeVotesType voteType)
 	
 	return true;
 }
+


### PR DESCRIPTION
Support doesn't extend to the SDK update, but works for now (PF2 isn't on Steam yet).